### PR TITLE
new settings for jammy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,7 @@ Standards-Version: 4.6.0.1
 
 Package: mamolinux-settings
 Architecture: all
-Depends: libpangox-1.0-0,
-         mamolinux-themes,
+Depends: mamolinux-themes,
          plank,
          synapse,
          ${python3:Depends},

--- a/etc/skel/.config/plank/dock1/launchers/gnome-system-monitor.dockitem
+++ b/etc/skel/.config/plank/dock1/launchers/gnome-system-monitor.dockitem
@@ -1,2 +1,0 @@
-[PlankDockItemPreferences]
-Launcher=file:///usr/share/applications/gnome-system-monitor.desktop

--- a/etc/skel/.config/plank/dock1/launchers/system-monitoring-center.dockitem
+++ b/etc/skel/.config/plank/dock1/launchers/system-monitoring-center.dockitem
@@ -1,0 +1,2 @@
+[PlankDockItemPreferences]
+Launcher=file:///usr/share/applications/system-monitoring-center.desktop

--- a/usr/share/glib-2.0/schemas/10_mamolinux-settings.gschema.override
+++ b/usr/share/glib-2.0/schemas/10_mamolinux-settings.gschema.override
@@ -22,7 +22,7 @@ togglekeys-enable-beep = true
 
 [org.cinnamon.desktop.background]
 picture-options = 'stretched'
-picture-uri = 'file:///usr/share/backgrounds/mamolinux-wallpapers/367789.jpg'
+picture-uri = 'file:///usr/share/backgrounds/jellyfish/jellyfish-1.jpg'
 
 [org.cinnamon.desktop.interface]
 clock-show-date = true
@@ -93,7 +93,7 @@ unplug-file = '/usr/share/sounds/freedesktop/stereo/device-removed.oga'
 name = 'Sucharu-Blue'
 
 [net.launchpad.plank.dock.settings]
-dock-items=['nemo.dockitem', 'org.gnome.Terminal.dockitem', 'firefox.dockitem', 'org.gnome.Evolution.dockitem', 'vlc.dockitem', 'org.gnome.Software.dockitem', 'gnome-system-monitor.dockitem', 'cinnamon-settings.dockitem', 'desktop.dockitem', 'trash.dockitem']
+dock-items=['nemo.dockitem', 'org.gnome.Terminal.dockitem', 'firefox.dockitem', 'org.gnome.Evolution.dockitem', 'vlc.dockitem', 'org.gnome.Software.dockitem', 'system-monitoring-center.dockitem', 'cinnamon-settings.dockitem', 'desktop.dockitem', 'trash.dockitem']
 theme = 'Sucharu'
 zoom-percent = 175
 zoom-enabled = true


### PR DESCRIPTION
- remove libpangox-1.0-0 from depends
- use system-monitoring-center to replace gnome-system-monitor on plank
- Use a jellyfish wallpaper as default