### PR TITLE
Fix plank themes for theme-manager

### DIFF
--- a/etc/mamolinux/.config/theme-manager/config.cfg
+++ b/etc/mamolinux/.config/theme-manager/config.cfg
@@ -15,7 +15,7 @@ cursor-theme-name = Sucharu
 cursor-color-variants = Aqua, Blue, Brown, Green, Grey, Orange, Pink, Purple, Red, Sand, Teal, Yellow
 plank-theme = True
 plank-theme-name = Sucharu
-plank-color-variants = "", Aqua, Blue, Brown, Grey, Orange, Pink, Purple, Red, Sand, Teal, Yellow
+plank-color-variants = "", aqua, blue, brown, grey, orange, pink, purple, red, sand, teal
 plank-dark-mode-suffix = Dark
 plank-theme-style-name = 0
 


### PR DESCRIPTION
- Sucharu now uses plank theme accents with lowercase letters